### PR TITLE
Cca 132 dodatkowe dzialania wykorzystanie hardware

### DIFF
--- a/CoreApp.py
+++ b/CoreApp.py
@@ -38,6 +38,7 @@ class CoreApp:
         self.container_directory = "/data/"
         self.apt_packages = {}
         self.pip_packages = {}
+        self.resources_and_access_management = {"Sharing graphics card resources": 0, "Display sharing": 0, "Sharing a sound card": 0, "Pip update": 0}
 
     def get_OS_data(self):
         return self.OS_data

--- a/createUtils/DockerComposeGenerator.py
+++ b/createUtils/DockerComposeGenerator.py
@@ -23,7 +23,10 @@ class DockerComposeGenerator:
                                        ports=self.coreApp.expose_ports,
                                        env_variables=self.coreApp.env_variables,
                                        restart=self.restart,
-                                       volumes=self.coreApp.volumes)
+                                       volumes=self.coreApp.volumes,
+                                       use_gpu=self.coreApp.resources_and_access_management["Sharing graphics card resources"],
+                                       use_display=self.coreApp.resources_and_access_management["Display sharing"],
+                                       use_sound=self.coreApp.resources_and_access_management["Sharing a sound card"])
         
         with open(os.path.join(self.coreApp.get_project_root_dir(), self.compose_name), "w") as file:
             file.write(content)

--- a/createUtils/DockerfileGenerator.py
+++ b/createUtils/DockerfileGenerator.py
@@ -38,6 +38,7 @@ class DockerfileGenerator:
         content = self.template.render(OS_image=self.coreApp.OS_data["OS_image"],
                                        OS_image_version=self.coreApp.OS_data["OS_image_version"],
                                        python_version=self.coreApp.python_version,
+                                       update_pip=self.coreApp.resources_and_access_management["Pip update"],
                                        packages_to_install=self.coreApp.chosen_pip_packages,
                                        apt_get_packages=res_apt_packages,
                                        use_requirements=self.coreApp.chosen_requirements,

--- a/gui/CheckboxWindow.py
+++ b/gui/CheckboxWindow.py
@@ -2,7 +2,7 @@ import tkinter as tk
 
 
 class CheckboxWindow(tk.Toplevel):
-    def __init__(self, parent, title, elements, callback):
+    def __init__(self, parent, title, elements, callback, callback1=None):
         super().__init__(parent)
 
         # variables
@@ -43,6 +43,10 @@ class CheckboxWindow(tk.Toplevel):
         button_frame.pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
         apply_button.pack(side=tk.LEFT, pady=self.padding, fill='x', expand=True)
         cancel_button.pack(side=tk.LEFT, pady=self.padding, fill='x', expand=True)
+
+        # suggestions
+        if callback1:
+            callback1()
 
     def apply(self):
         self.callback(self.checkboxes)

--- a/gui/CheckboxWindow.py
+++ b/gui/CheckboxWindow.py
@@ -2,7 +2,7 @@ import tkinter as tk
 
 
 class CheckboxWindow(tk.Toplevel):
-    def __init__(self, parent, title, elements, callback, callback1=None):
+    def __init__(self, parent, title, elements, callback):
         super().__init__(parent)
 
         # variables
@@ -43,10 +43,6 @@ class CheckboxWindow(tk.Toplevel):
         button_frame.pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
         apply_button.pack(side=tk.LEFT, pady=self.padding, fill='x', expand=True)
         cancel_button.pack(side=tk.LEFT, pady=self.padding, fill='x', expand=True)
-
-        # suggestions
-        if callback1:
-            callback1()
 
     def apply(self):
         self.callback(self.checkboxes)

--- a/gui/CheckboxWindow.py
+++ b/gui/CheckboxWindow.py
@@ -1,0 +1,49 @@
+import tkinter as tk
+
+
+class CheckboxWindow(tk.Toplevel):
+    def __init__(self, parent, title, elements, callback):
+        super().__init__(parent)
+
+        # variables
+        self.parent = parent
+        self.row = 1
+        self.checkboxes = []
+        self.callback = callback
+
+        # window properties
+        self.title(title)
+        self.window_width = 600
+        self.window_height = 400
+        self.screen_width = self.winfo_screenwidth()
+        self.screen_height = self.winfo_screenheight()
+        self.padding = 5
+        center_x = int(self.screen_width / 2 - self.window_width / 2)
+        center_y = int(self.screen_height / 2 - self.window_height / 2)
+        self.geometry(f'{self.window_width}x{self.window_height}+{center_x}+{center_y}')
+
+        # list with checkboxes
+        frame = tk.Frame(self)
+        for key, value in elements.items():
+            # check button
+            checked = tk.IntVar()
+            checked.set(value)
+            checkbox = tk.Checkbutton(frame, variable=checked, text=key)
+            checkbox.grid(row=self.row, column=1, sticky="w")
+
+            self.row += 1
+            self.checkboxes.append((key, checked))
+
+        # buttons
+        button_frame = tk.Frame(self)
+        apply_button = tk.Button(button_frame, text="Apply", command=lambda: self.apply())
+        cancel_button = tk.Button(button_frame, text="Cancel", command=self.destroy)
+
+        frame.pack()
+        button_frame.pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
+        apply_button.pack(side=tk.LEFT, pady=self.padding, fill='x', expand=True)
+        cancel_button.pack(side=tk.LEFT, pady=self.padding, fill='x', expand=True)
+
+    def apply(self):
+        self.callback(self.checkboxes)
+        self.destroy()

--- a/gui/GeneratorWindow.py
+++ b/gui/GeneratorWindow.py
@@ -10,13 +10,12 @@ from gui.FilesNotFoundWindow import FilesNotFoundWindow
 
 
 class GeneratorWindow(tk.Toplevel):
-    def __init__(self, parent, suggestions_function):
+    def __init__(self, parent):
         super().__init__(parent)
         self.window_width = 600
         self.window_height = 400
         self.padding = 5
-        self.suggestions_function = suggestions_function
-        
+
         self.title("Generate Files")
         center_x = int(parent.screen_width/2 - self.window_width / 2)
         center_y = int(parent.screen_height/2 - self.window_height / 2)
@@ -61,9 +60,6 @@ class GeneratorWindow(tk.Toplevel):
         create_dockerfile_button.pack(side=tk.LEFT, pady=self.padding, fill='x', expand=True)
         self.create_compose_button.pack(side=tk.LEFT, pady=self.padding, fill='x', expand=True)
         cancel_button.pack(side=tk.LEFT, pady=self.padding, fill='x', expand=True)
-
-        # suggestion
-        suggestions_function()
         
     def search_for_dockerfile(self, parent):
         pattern = re.compile(r".*Dockerfile.*")

--- a/gui/GeneratorWindow.py
+++ b/gui/GeneratorWindow.py
@@ -10,11 +10,12 @@ from gui.FilesNotFoundWindow import FilesNotFoundWindow
 
 
 class GeneratorWindow(tk.Toplevel):
-    def __init__(self, parent):
+    def __init__(self, parent, suggestions_function):
         super().__init__(parent)
         self.window_width = 600
         self.window_height = 400
         self.padding = 5
+        self.suggestions_function = suggestions_function
         
         self.title("Generate Files")
         center_x = int(parent.screen_width/2 - self.window_width / 2)
@@ -60,6 +61,9 @@ class GeneratorWindow(tk.Toplevel):
         create_dockerfile_button.pack(side=tk.LEFT, pady=self.padding, fill='x', expand=True)
         self.create_compose_button.pack(side=tk.LEFT, pady=self.padding, fill='x', expand=True)
         cancel_button.pack(side=tk.LEFT, pady=self.padding, fill='x', expand=True)
+
+        # suggestion
+        suggestions_function()
         
     def search_for_dockerfile(self, parent):
         pattern = re.compile(r".*Dockerfile.*")

--- a/gui/MainApp.py
+++ b/gui/MainApp.py
@@ -4,6 +4,7 @@ from tkinter import messagebox
 from tkinter.messagebox import askyesno
 from ProjectTree import ProjectTree
 from gui.BasicConfigurationWindow import BasicConfigurationWindow
+from gui.CheckboxWindow import CheckboxWindow
 from gui.TreeWindow import TreeWindow
 from gui.ManageRequirementsWindow import ManageRequirementsWindow
 from gui.GeneratorWindow import GeneratorWindow
@@ -25,7 +26,7 @@ class App(tk.Tk):
         self.title("Code Container")
         
         self.window_width = 600
-        self.window_height = 500
+        self.window_height = 550
         self.screen_width = self.winfo_screenwidth()
         self.screen_height = self.winfo_screenheight()
         self.padding = 15
@@ -53,7 +54,9 @@ class App(tk.Tk):
         self.manage_requirements_button = tk.Button(mainframe, text="Manage requirements", state=tk.DISABLED, command=lambda: self.open_manage_requirements_window())
         
         self.package_list_button = tk.Button(mainframe, text="Select apt and pip packages", state=tk.DISABLED, command=lambda: self.open_packages_list_window())
-        
+
+        self.resource_and_access_button = tk.Button(mainframe, text="Resource & Access Management", state=tk.DISABLED, command=lambda: self.open_resource_and_access_window())
+
         self.send_button = tk.Button(mainframe, text = "Generate", state=tk.DISABLED, command=lambda:self.open_generate())
         
         self.add_attributes_button = tk.Button(mainframe, text = "Customize Attributes", state=tk.DISABLED, command=lambda:self.open_add_attributes())
@@ -77,8 +80,9 @@ class App(tk.Tk):
         self.manage_requirements_button.grid(row = 4, column=2, sticky='nsew', pady = self.padding)
         self.package_list_button.grid(row = 5, column=2, sticky='nsew', pady = self.padding)
         self.add_attributes_button.grid(row = 6, column=2, sticky='nsew', pady = self.padding)
-        self.send_button.grid(row = 7, column=2, sticky='nsew', pady = self.padding)
-        exit_button.grid(row = 8, column=2, sticky='nsew', pady = self.padding)
+        self.resource_and_access_button.grid(row = 7, column=2, sticky='nsew', pady = self.padding)
+        self.send_button.grid(row = 8, column=2, sticky='nsew', pady = self.padding)
+        exit_button.grid(row = 9, column=2, sticky='nsew', pady = self.padding)
         
     def open_tree_window(self):
         tree_window = TreeWindow(self)
@@ -101,6 +105,7 @@ class App(tk.Tk):
             self.send_button['state'] = tk.NORMAL
             self.package_list_button['state'] = tk.NORMAL
             self.add_attributes_button['state'] = tk.NORMAL
+            self.resource_and_access_button['state'] = tk.NORMAL
 
     def set_chosen_requirements(self, chosen_requirements, file_names, apt_packages, requirements_pip_packages):
         self.coreApp.set_chosen_requirements(chosen_requirements)
@@ -142,7 +147,16 @@ class App(tk.Tk):
     def open_add_attributes(self):
         self.add_attributes_window = AddAttributesWindow(self)
         self.add_attributes_window.grab_set()
-        
+
+    def save_resource_and_access_window(self, checkboxes):
+        for item, checked in checkboxes:
+            print(f"{item}: {checked}")
+            self.coreApp.resources_and_access_management[item] = checked.get()
+
+    def open_resource_and_access_window(self):
+        open_resource_and_access_window = CheckboxWindow(parent=self, title="Resource & Access Management", elements=self.coreApp.resources_and_access_management, callback=self.save_resource_and_access_window)
+        open_resource_and_access_window.grab_set()
+
     def on_closing(self):
         if messagebox.askokcancel("Quit", "Do you want to quit?"):
             path = self.coreApp.get_project_root_dir()

--- a/gui/MainApp.py
+++ b/gui/MainApp.py
@@ -139,14 +139,17 @@ class App(tk.Tk):
             self.project_tree_button['state'] = tk.NORMAL
             self.basic_configuration_button['state'] = tk.NORMAL
             self.check_os_and_python()
-            
+
+    def suggestions(self):
+        tk.messagebox.showinfo(title="Suggestions", message="Suggestions")
+
     def open_generate(self):
-        self.generate_window = GeneratorWindow(self)
-        self.generate_window.grab_set()
+        generate_window = GeneratorWindow(parent=self, suggestions_function=self.suggestions)
+        generate_window.grab_set()
         
     def open_add_attributes(self):
-        self.add_attributes_window = AddAttributesWindow(self)
-        self.add_attributes_window.grab_set()
+        add_attributes_window = AddAttributesWindow(self)
+        add_attributes_window.grab_set()
 
     def save_resource_and_access_window(self, checkboxes):
         for item, checked in checkboxes:
@@ -154,7 +157,7 @@ class App(tk.Tk):
             self.coreApp.resources_and_access_management[item] = checked.get()
 
     def open_resource_and_access_window(self):
-        open_resource_and_access_window = CheckboxWindow(parent=self, title="Resource & Access Management", elements=self.coreApp.resources_and_access_management, callback=self.save_resource_and_access_window)
+        open_resource_and_access_window = CheckboxWindow(parent=self, title="Resource & Access Management", elements=self.coreApp.resources_and_access_management, callback=self.save_resource_and_access_window, callback1=self.suggestions)
         open_resource_and_access_window.grab_set()
 
     def on_closing(self):

--- a/gui/MainApp.py
+++ b/gui/MainApp.py
@@ -140,11 +140,8 @@ class App(tk.Tk):
             self.basic_configuration_button['state'] = tk.NORMAL
             self.check_os_and_python()
 
-    def suggestions(self):
-        tk.messagebox.showinfo(title="Suggestions", message="Suggestions")
-
     def open_generate(self):
-        generate_window = GeneratorWindow(parent=self, suggestions_function=self.suggestions)
+        generate_window = GeneratorWindow(parent=self)
         generate_window.grab_set()
         
     def open_add_attributes(self):
@@ -157,7 +154,7 @@ class App(tk.Tk):
             self.coreApp.resources_and_access_management[item] = checked.get()
 
     def open_resource_and_access_window(self):
-        open_resource_and_access_window = CheckboxWindow(parent=self, title="Resource & Access Management", elements=self.coreApp.resources_and_access_management, callback=self.save_resource_and_access_window, callback1=self.suggestions)
+        open_resource_and_access_window = CheckboxWindow(parent=self, title="Resource & Access Management", elements=self.coreApp.resources_and_access_management, callback=self.save_resource_and_access_window)
         open_resource_and_access_window.grab_set()
 
     def on_closing(self):

--- a/templates/template-docker-compose.txt
+++ b/templates/template-docker-compose.txt
@@ -4,11 +4,16 @@ services:
         build:
             context: {{ context }}
             dockerfile: {{ dockerfile_name }}
-        {% if env_variables %}
+        {% if env_variables or use_display or use_sound %}
         environment:
+            {% if env_variables %}
             {% for key, value in env_variables.items() %}
             {{ key }}={{ value }}
             {% endfor %}
+            {% endif %}
+            {% if use_display or use_sound %}
+            - DISPLAY=${DISPLAY}
+            {% endif %}
         {% endif %}
         {% if ports %}
         ports:
@@ -18,10 +23,28 @@ services:
             {% endif %}
             {% endfor %}
         {% endif %}
-        {% if volumes %}
+        {% if volumes or use_display or use_sound %}
         volumes:
+            {% if volumes %}
             {% for host_path, container_port in volumes.items() %}
             - {{ host_path }}:{{ container_port }}
             {% endfor %}
+            {% endif %}
+            {% if use_display or use_sound %}
+            - /tmp/.X11-unix:/tmp/.X11-unix
+            {% endif %}
+        {% endif %}
+        {% if use_sound %}
+        devices:
+            - "/dev/snd:/dev/snd"
+        {% endif %}
+        {% if use_gpu %}
+        deploy:
+            resources:
+                reservations:
+                    devices:
+                    - driver: nvidia
+                      count: all
+                      capabilities: [gpu]
         {% endif %}
         restart: {{ restart }}

--- a/templates/template-dockerfile-apt.txt
+++ b/templates/template-dockerfile-apt.txt
@@ -30,7 +30,9 @@ RUN eval "$(pyenv init -)" && \
     pyenv global {{ python_version }}
 RUN python -m venv venv
 ENV PATH="venv/bin:$PATH"
+{% if update_pip %}
 RUN pip install --upgrade pip
+{% endif %}
 
 {% if commands_before_files %}
 {% for command in commands_before_files %}

--- a/templates/template-dockerfile-copy.txt
+++ b/templates/template-dockerfile-copy.txt
@@ -28,7 +28,9 @@ RUN eval "$(pyenv init -)" && \
     pyenv global {{ python_version }}
 RUN python -m venv venv
 ENV PATH="venv/bin:$PATH"
+{% if update_pip %}
 RUN pip install --upgrade pip
+{% endif %}
 
 RUN --mount=type=cache,target=/var/cache/apt \ 
     apt-get update \


### PR DESCRIPTION
Zaznacz wszystkie opcje i sprawdź ich działanie. Aby udostępnić kartę główną do kontenera, na hoście należy zainstalować potrzebne pakiety: 
```
distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
sudo apt-get update
sudo apt-get install -y nvidia-docker2
sudo systemctl restart docker
```
To musi znaleźć się w instrukcji